### PR TITLE
Title & Patch Error Feedback

### DIFF
--- a/patchserver/var/www/webadmin/manageTitle.php
+++ b/patchserver/var/www/webadmin/manageTitle.php
@@ -843,10 +843,14 @@ $(document).ready(function() {
 							<?php foreach ($patches as $patch) { ?>
 							<tr>
 								<td>
+									<?php if (sizeof($patch['error']) == 0) { ?>
 									<div class="checkbox checkbox-primary">
-										<input type="checkbox" class="styled" name="enable_patch" id="enable_patch" value="<?php echo $patch['id']; ?>" onChange="togglePatch(this); updateTimestamp(<?php echo $title_id; ?>);" <?php echo (sizeof($patch['error']) > 0) ? "disabled " : ""; ?><?php echo ($patch['enabled'] == "1" && sizeof($patch['error']) == 0) ? "checked " : ""; ?>/>
+										<input type="checkbox" class="styled" name="enable_patch" id="enable_patch" value="<?php echo $patch['id']; ?>" onChange="togglePatch(this); updateTimestamp(<?php echo $title_id; ?>);" <?php echo ($patch['enabled'] == "1") ? "checked" : ""; ?>/>
 										<label/>
 									</div>
+									<?php } else { ?>
+									<div style="padding-left: 16px; padding-top: 2px;"><a href="managePatch.php?id=<?php echo $patch['id']; ?>"><span class="glyphicon glyphicon-exclamation-sign text-danger" style="font-size: 17px;"></span></a></div>
+									<?php } ?>
 								</td>
 								<td><input type="hidden" name="patch_order[<?php echo $patch['id']; ?>]" value="<?php echo $patch['sort_order']; ?>"/><?php echo $patch['sort_order']; ?></td>
 								<td nowrap><a href="managePatch.php?id=<?php echo $patch['id']; ?>"><?php echo $patch['version']; ?></a></td>

--- a/patchserver/var/www/webadmin/patchTitles.php
+++ b/patchserver/var/www/webadmin/patchTitles.php
@@ -148,10 +148,14 @@ $(document).ready(function() {
 					<?php foreach ($sw_titles as $sw_title) { ?>
 					<tr>
 						<td>
+							<?php if (sizeof($sw_title['error']) == 0) { ?>
 							<div class="checkbox checkbox-primary">
-								<input type="checkbox" class="styled" name="enable_title" id="enable_title" value="<?php echo $sw_title['id']; ?>" onChange="javascript:ajaxPost('patchCtl.php?title_id='+this.value, 'title_enabled='+this.checked);" <?php echo (sizeof($sw_title['error']) > 0) ? "disabled " : ""; ?><?php echo ($sw_title['enabled'] == "1" && sizeof($sw_title['error']) == 0) ? "checked " : ""; ?>/>
+								<input type="checkbox" class="styled" name="enable_title" id="enable_title" value="<?php echo $sw_title['id']; ?>" onChange="javascript:ajaxPost('patchCtl.php?title_id='+this.value, 'title_enabled='+this.checked);" <?php echo ($sw_title['enabled'] == "1") ? "checked " : ""; ?>/>
 								<label/>
 							</div>
+							<?php } else { ?>
+							<div style="padding-left: 16px; padding-top: 2px;"><a href="manageTitle.php?id=<?php echo $sw_title['id']; ?>"><span class="glyphicon glyphicon-exclamation-sign text-danger" style="font-size: 17px;"></span></a></div>
+							<?php } ?>
 						</td>
 						<td nowrap><a href="manageTitle.php?id=<?php echo $sw_title['id']; ?>"><?php echo $sw_title['name']; ?></a></td>
 						<td nowrap><?php echo $sw_title['publisher']; ?></td>


### PR DESCRIPTION
If a patch or title contains an error which prevents it from being enabled, the checkbox is now replaced with an error icon which if clicked will take you to the offending component